### PR TITLE
Map Windows before calling XGetImage

### DIFF
--- a/src/natives/screenshot/linux/screenshot.cpp
+++ b/src/natives/screenshot/linux/screenshot.cpp
@@ -43,6 +43,7 @@ struct Image {
             (unsigned char**)&activeWindow
         );
 
+        XMapWindow(display, drawable);
         XRaiseWindow(display, (Window) drawable);
         XSync(display, False);
         usleep(500000);


### PR DESCRIPTION
Mapping the Window before calling `XGetImage` is required for me on i3
If don't do it I get a failure for `XGetImage`
```
  X Error of failed request:  BadMatch (invalid parameter attributes)                                                                                                                                                                        
    Major opcode of failed request:  73 (X_GetImage)                                                                                                                                                                                         
    Serial number of failed request:  13                                                                                                                                                                                                     
    Current serial number in output stream:  13                                                                                                                                                                                              
```