### PR TITLE
update device list (closes #3767 in testcafe)

### DIFF
--- a/data/devices.json
+++ b/data/devices.json
@@ -1,1 +1,1887 @@
-{"acericoniataba1-810":{"portraitWidth":768,"landscapeWidth":1024,"name":"Acer Iconia Tab A1-810"},"acericoniataba100":{"portraitWidth":800,"landscapeWidth":1280,"name":"Acer Iconia Tab A100"},"acericoniataba101":{"portraitWidth":600,"landscapeWidth":1024,"name":"Acer Iconia Tab A101"},"acericoniataba200":{"portraitWidth":800,"landscapeWidth":1280,"name":"Acer Iconia Tab A200"},"acericoniataba500":{"portraitWidth":648,"landscapeWidth":1280,"name":"Acer Iconia Tab A500"},"acericoniataba501":{"portraitWidth":800,"landscapeWidth":1280,"name":"Acer Iconia Tab A501"},"acerliquide2":{"portraitWidth":360,"landscapeWidth":640,"name":"ACER Liquid E2"},"ainolnovo7elf2":{"portraitWidth":496,"landscapeWidth":1024,"name":"Ainol Novo 7 Elf 2"},"alcatelonetouchidolx":{"portraitWidth":480,"landscapeWidth":800,"name":"Alcatel One Touch Idol X"},"alcatelonetoucht10":{"portraitWidth":480,"landscapeWidth":800,"name":"Alcatel One Touch T10"},"alcatelonetouch903":{"portraitWidth":320,"landscapeWidth":427,"name":"Alcatel One Touch 903"},"alcatel(vodafone)smartmini875":{"portraitWidth":320,"landscapeWidth":480,"name":"Alcatel (Vodafone) Smart Mini 875"},"amicroe7touchtabii":{"portraitWidth":480,"landscapeWidth":800,"name":"Amicroe 7 TouchTAB II"},"amicroe9.7touchtabiv":{"portraitWidth":768,"landscapeWidth":1024,"name":"Amicroe 9.7 TouchTAB IV"},"archos70b(it2)":{"portraitWidth":600,"landscapeWidth":1024,"name":"Archos 70b (it2)"},"archos80g9":{"portraitWidth":768,"landscapeWidth":1024,"name":"Archos 80G9"},"arnova10bg3":{"portraitWidth":600,"landscapeWidth":1024,"name":"Arnova 10b G3"},"arnova7g2":{"portraitWidth":480,"landscapeWidth":800,"name":"Arnova 7 G2"},"arnova7fg3":{"portraitWidth":640,"landscapeWidth":1067,"name":"Arnova 7F G3"},"arnova8cg3":{"portraitWidth":800,"landscapeWidth":1067,"name":"Arnova 8C G3"},"asusb1-a71":{"portraitWidth":600,"landscapeWidth":1024,"name":"ASUS B1-A71"},"asusfonepad":{"portraitWidth":601,"landscapeWidth":962,"name":"ASUS Fonepad"},"asusmemopadme172v":{"portraitWidth":600,"landscapeWidth":1024,"name":"ASUS MeMo Pad ME172V"},"asusmemopadfhd10/me302c10.1":{"portraitWidth":800,"landscapeWidth":1280,"name":"ASUS MeMo Pad FHD10/ME302C 10.1"},"asuspadfone":{"portraitWidth":800,"landscapeWidth":1128,"name":"ASUS Padfone"},"asustransformerpadtf300t":{"portraitWidth":800,"landscapeWidth":1280,"name":"ASUS Transformer Pad TF300T"},"asustransformertf101":{"portraitWidth":800,"landscapeWidth":1280,"name":"ASUS Transformer TF101"},"asusvivo":{"portraitWidth":768,"landscapeWidth":1366,"name":"ASUS Vivo"},"barnes&amp;noblenookhd":{"portraitWidth":600,"landscapeWidth":960,"name":"Barnes &amp; Noble Nook HD"},"bauhnamid-972xs":{"portraitWidth":768,"landscapeWidth":1024,"name":"BAUHN AMID-972XS"},"bauhnamid-9743g":{"portraitWidth":768,"landscapeWidth":1024,"name":"BAUHN AMID-9743G"},"bauhnasp-5000h":{"portraitWidth":360,"landscapeWidth":640,"name":"BAUHN ASP-5000H"},"blackberry9520":{"portraitWidth":345,"landscapeWidth":691,"name":"BlackBerry 9520"},"blackberrycurve9380":{"portraitWidth":320,"landscapeWidth":406,"name":"BlackBerry Curve 9380"},"blackberryplaybook":{"portraitWidth":600,"landscapeWidth":1024,"name":"BlackBerry PlayBook"},"blackberrytorch9800":{"portraitWidth":360,"landscapeWidth":480,"name":"BlackBerry Torch 9800"},"blackberrytorch9860":{"portraitWidth":320,"landscapeWidth":505,"name":"BlackBerry Torch 9860"},"blackberryz10":{"portraitWidth":342,"landscapeWidth":570,"name":"BlackBerry Z10"},"dellvenue8":{"portraitWidth":800,"landscapeWidth":1280,"name":"Dell Venue 8"},"galaxynexus":{"portraitWidth":360,"landscapeWidth":598,"name":"Galaxy Nexus"},"hpslate72800":{"portraitWidth":600,"landscapeWidth":1024,"name":"HP Slate 7 2800"},"hptouchpad":{"portraitWidth":768,"landscapeWidth":1024,"name":"HP Touchpad"},"hpveer":{"portraitWidth":320,"landscapeWidth":545,"name":"HP Veer"},"htc7mozart":{"portraitWidth":320,"landscapeWidth":480,"name":"HTC 7 Mozart"},"htc7trophy":{"portraitWidth":320,"landscapeWidth":480,"name":"HTC 7 Trophy"},"htca620b":{"portraitWidth":320,"landscapeWidth":480,"name":"HTC A620b"},"htcdesire":{"portraitWidth":320,"landscapeWidth":533,"name":"HTC Desire"},"htcdesirec":{"portraitWidth":320,"landscapeWidth":480,"name":"HTC Desire C"},"htcdesirehd":{"portraitWidth":320,"landscapeWidth":533,"name":"HTC Desire HD"},"htcdesires":{"portraitWidth":320,"landscapeWidth":533,"name":"HTC Desire S"},"htcdesirex":{"portraitWidth":320,"landscapeWidth":533,"name":"HTC Desire X"},"htcdesire700":{"portraitWidth":360,"landscapeWidth":640,"name":"HTC Desire 700"},"htcdesirez(vision)":{"portraitWidth":480,"landscapeWidth":800,"name":"HTC Desire Z (Vision)"},"htcdroideris":{"portraitWidth":320,"landscapeWidth":480,"name":"HTC Droid Eris"},"htcevo3d":{"portraitWidth":540,"landscapeWidth":960,"name":"HTC Evo 3D"},"htcincredible2":{"portraitWidth":320,"landscapeWidth":533,"name":"HTC Incredible 2"},"htclegend":{"portraitWidth":320,"landscapeWidth":480,"name":"HTC Legend"},"htcmytouchslide4g":{"portraitWidth":320,"landscapeWidth":533,"name":"HTC MyTouch Slide 4G"},"htcone":{"portraitWidth":360,"landscapeWidth":640,"name":"HTC One"},"htconemini":{"portraitWidth":360,"landscapeWidth":640,"name":"HTC One Mini"},"htcones":{"portraitWidth":360,"landscapeWidth":640,"name":"HTC One S"},"htconesv":{"portraitWidth":320,"landscapeWidth":533,"name":"HTC One SV"},"htconev":{"portraitWidth":320,"landscapeWidth":533,"name":"HTC One V"},"htconex":{"portraitWidth":360,"landscapeWidth":640,"name":"HTC One X"},"htconex+":{"portraitWidth":360,"landscapeWidth":640,"name":"HTC One X+"},"htconexl":{"portraitWidth":360,"landscapeWidth":640,"name":"HTC One XL"},"htcrio8s":{"portraitWidth":320,"landscapeWidth":480,"name":"HTC Rio 8S"},"htcsensationxl":{"portraitWidth":360,"landscapeWidth":640,"name":"HTC Sensation XL"},"htctitanii/4g":{"portraitWidth":320,"landscapeWidth":480,"name":"HTC Titan II/4G"},"htcvelocity4g":{"portraitWidth":360,"landscapeWidth":640,"name":"HTC Velocity 4G"},"htcwildfirea3333":{"portraitWidth":267,"landscapeWidth":356,"name":"HTC Wildfire A3333"},"htcwildfires":{"portraitWidth":320,"landscapeWidth":480,"name":"HTC Wildfire S"},"htcwindowsphone8s":{"portraitWidth":320,"landscapeWidth":480,"name":"HTC Windows Phone 8S"},"htcwindowsphone8x(c625b)":{"portraitWidth":320,"landscapeWidth":480,"name":"HTC Windows Phone 8X (C625b)"},"huaweiascendg510":{"portraitWidth":320,"landscapeWidth":569,"name":"Huawei Ascend G510"},"huaweiascendmate":{"portraitWidth":480,"landscapeWidth":813,"name":"Huawei Ascend Mate"},"huaweiu8650sonic":{"portraitWidth":320,"landscapeWidth":480,"name":"Huawei U8650 Sonic"},"huaweiu8860":{"portraitWidth":320,"landscapeWidth":544,"name":"Huawei U8860"},"huaweiy300-0151":{"portraitWidth":320,"landscapeWidth":533,"name":"Huawei Y300-0151"},"ipad":{"portraitWidth":768,"landscapeWidth":1024,"name":"iPad"},"ipad2":{"portraitWidth":768,"landscapeWidth":1024,"name":"iPad 2"},"ipad3":{"portraitWidth":768,"landscapeWidth":1024,"name":"iPad 3"},"ipadair":{"portraitWidth":768,"landscapeWidth":1024,"name":"iPad Air"},"ipadmini":{"portraitWidth":768,"landscapeWidth":1024,"name":"iPad Mini"},"iphone":{"portraitWidth":320,"landscapeWidth":480,"name":"iPhone"},"iphone3g":{"portraitWidth":320,"landscapeWidth":480,"name":"iPhone 3G"},"iphone3gs":{"portraitWidth":320,"landscapeWidth":480,"name":"iPhone 3GS"},"iphone4":{"portraitWidth":320,"landscapeWidth":480,"name":"iPhone 4"},"iphone4s":{"portraitWidth":320,"landscapeWidth":480,"name":"iPhone 4S"},"iphone5":{"portraitWidth":320,"landscapeWidth":568,"name":"iPhone 5"},"iphone5c":{"portraitWidth":320,"landscapeWidth":568,"name":"iPhone 5c"},"iphone5s":{"portraitWidth":320,"landscapeWidth":568,"name":"iPhone 5s"},"iphone6":{"portraitWidth":375,"landscapeWidth":667,"name":"iPhone 6"},"iphone6plus":{"portraitWidth":414,"landscapeWidth":736,"name":"iPhone 6 Plus"},"ipodtouch4thgen":{"portraitWidth":320,"landscapeWidth":480,"name":"iPod Touch 4th Gen"},"ipodtouch5thgen":{"portraitWidth":320,"landscapeWidth":568,"name":"iPod Touch 5th Gen"},"kindlefire2":{"portraitWidth":600,"landscapeWidth":963,"name":"Kindle Fire 2"},"kindlefirehd":{"portraitWidth":533,"landscapeWidth":801,"name":"Kindle Fire HD"},"kindlefirehd8.9":{"portraitWidth":800,"landscapeWidth":1220,"name":"Kindle Fire HD 8.9"},"lenovoideataba1000":{"portraitWidth":600,"landscapeWidth":1024,"name":"Lenovo IdeaTab A1000"},"lenovoideatabs6000":{"portraitWidth":800,"landscapeWidth":1280,"name":"Lenovo IdeaTab S6000"},"lenovoyogatablet8":{"portraitWidth":602,"landscapeWidth":962,"name":"Lenovo Yoga Tablet 8"},"lenovoyogatablet10":{"portraitWidth":800,"landscapeWidth":1280,"name":"Lenovo Yoga Tablet 10"},"lgally":{"portraitWidth":320,"landscapeWidth":533,"name":"LG Ally"},"lgg2":{"portraitWidth":360,"landscapeWidth":598,"name":"LG G2"},"lgoptimus2x":{"portraitWidth":320,"landscapeWidth":533,"name":"LG Optimus 2x"},"lgoptimusblackp970":{"portraitWidth":320,"landscapeWidth":533,"name":"LG Optimus Black P970"},"lgoptimusge975":{"portraitWidth":384,"landscapeWidth":640,"name":"LG Optimus G E975"},"lgoptimusl3e400":{"portraitWidth":320,"landscapeWidth":427,"name":"LG Optimus L3 E400"},"lgoptimusl3iie425f":{"portraitWidth":320,"landscapeWidth":427,"name":"LG Optimus L3 II E425f"},"lgoptimusl7p700":{"portraitWidth":320,"landscapeWidth":533,"name":"LG Optimus L7 P700"},"lgoptimusl9p760":{"portraitWidth":360,"landscapeWidth":640,"name":"LG Optimus L9 P760"},"lgoptimuspadv900":{"portraitWidth":768,"landscapeWidth":1280,"name":"LG Optimus Pad V900"},"lgviewtyku990":{"portraitWidth":240,"landscapeWidth":400,"name":"LG Viewty KU990"},"microsoftsurface":{"portraitWidth":768,"landscapeWidth":1366,"name":"Microsoft Surface"},"microsoftsurfacepro":{"portraitWidth":720,"landscapeWidth":1280,"name":"Microsoft Surface Pro"},"motoroladefy":{"portraitWidth":320,"landscapeWidth":569,"name":"Motorola Defy"},"motoroladefymini":{"portraitWidth":320,"landscapeWidth":480,"name":"Motorola Defy Mini"},"motoroladroidbionic":{"portraitWidth":360,"landscapeWidth":640,"name":"Motorola Droid Bionic"},"motoroladroidrazr":{"portraitWidth":360,"landscapeWidth":640,"name":"Motorola Droid Razr"},"motoroladroid3":{"portraitWidth":360,"landscapeWidth":559,"name":"Motorola Droid 3"},"motorolaelectrify2":{"portraitWidth":360,"landscapeWidth":598,"name":"Motorola Electrify 2"},"motorolafirext":{"portraitWidth":320,"landscapeWidth":480,"name":"Motorola Fire XT"},"motorolaflipout":{"portraitWidth":320,"landscapeWidth":240,"name":"Motorola FlipOut"},"motorolamilestone":{"portraitWidth":320,"landscapeWidth":569,"name":"Motorola Milestone"},"motorolamotog":{"portraitWidth":360,"landscapeWidth":598,"name":"Motorola Moto G"},"motorolarazrhd4g":{"portraitWidth":360,"landscapeWidth":598,"name":"Motorola RAZR HD 4G"},"motorolarazrm4g":{"portraitWidth":360,"landscapeWidth":598,"name":"Motorola RAZR M 4G"},"motorolarazrmaxx":{"portraitWidth":360,"landscapeWidth":640,"name":"Motorola RAZR MAXX"},"motorolaxoom":{"portraitWidth":800,"landscapeWidth":1280,"name":"Motorola Xoom"},"motorolaxoom2":{"portraitWidth":800,"landscapeWidth":1280,"name":"Motorola Xoom 2"},"motorolaxoom2mediaedition":{"portraitWidth":800,"landscapeWidth":1280,"name":"Motorola Xoom 2 Media Edition"},"nexus10":{"portraitWidth":800,"landscapeWidth":1280,"name":"Nexus 10"},"nexus4":{"portraitWidth":384,"landscapeWidth":598,"name":"Nexus 4"},"nexus5":{"portraitWidth":360,"landscapeWidth":598,"name":"Nexus 5"},"nexus7":{"portraitWidth":601,"landscapeWidth":962,"name":"Nexus 7"},"nexus7(lcddensitysetto175ppi)":{"portraitWidth":731,"landscapeWidth":1170,"name":"Nexus 7 (LCD Density set to 175PPI)"},"nexus7(2013)":{"portraitWidth":600,"landscapeWidth":960,"name":"Nexus 7 (2013)"},"nexusone":{"portraitWidth":320,"landscapeWidth":533,"name":"Nexus One"},"nexuss":{"portraitWidth":320,"landscapeWidth":533,"name":"Nexus S"},"nokia500":{"portraitWidth":360,"landscapeWidth":640,"name":"Nokia 500"},"nokia700(operamobile)":{"portraitWidth":240,"landscapeWidth":427,"name":"Nokia 700 (Opera Mobile)"},"nokialumia520":{"portraitWidth":320,"landscapeWidth":480,"name":"Nokia Lumia 520"},"nokialumia610":{"portraitWidth":320,"landscapeWidth":480,"name":"Nokia Lumia 610"},"nokialumia710":{"portraitWidth":320,"landscapeWidth":480,"name":"Nokia Lumia 710"},"nokialumia720":{"portraitWidth":320,"landscapeWidth":480,"name":"Nokia Lumia 720"},"nokialumia800":{"portraitWidth":320,"landscapeWidth":480,"name":"Nokia Lumia 800"},"nokialumia820":{"portraitWidth":320,"landscapeWidth":480,"name":"Nokia Lumia 820"},"nokialumia900":{"portraitWidth":320,"landscapeWidth":480,"name":"Nokia Lumia 900"},"nokialumia920":{"portraitWidth":320,"landscapeWidth":480,"name":"Nokia Lumia 920"},"nokialumia925":{"portraitWidth":320,"landscapeWidth":480,"name":"Nokia Lumia 925"},"nokialumia1520":{"portraitWidth":320,"landscapeWidth":480,"name":"Nokia Lumia 1520"},"nokian9":{"portraitWidth":320,"landscapeWidth":496,"name":"Nokia N9"},"nokian900":{"portraitWidth":480,"landscapeWidth":800,"name":"Nokia N900"},"palmpixi":{"portraitWidth":320,"landscapeWidth":480,"name":"Palm Pixi"},"panasonictoughpadfz-a1":{"portraitWidth":768,"landscapeWidth":1024,"name":"Panasonic Toughpad FZ-A1"},"pendopad7&quot;":{"portraitWidth":480,"landscapeWidth":800,"name":"PendoPad 7&quot;"},"pendopad10&quot;":{"portraitWidth":600,"landscapeWidth":1024,"name":"PendoPad 10&quot;"},"pioneerdreambook":{"portraitWidth":768,"landscapeWidth":1024,"name":"Pioneer Dreambook"},"samsungativs":{"portraitWidth":320,"landscapeWidth":480,"name":"Samsung Ativ S"},"samsunggalaxy5/europai5500":{"portraitWidth":320,"landscapeWidth":427,"name":"Samsung Galaxy 5/Europa I5500"},"samsunggalaxyaces5830":{"portraitWidth":320,"landscapeWidth":480,"name":"Samsung Galaxy Ace S5830"},"samsunggalaxyace2i8160":{"portraitWidth":320,"landscapeWidth":533,"name":"Samsung Galaxy Ace 2 I8160"},"samsunggalaxyacepluss7500":{"portraitWidth":320,"landscapeWidth":480,"name":"Samsung Galaxy Ace Plus S7500"},"samsunggalaxybeami8530":{"portraitWidth":320,"landscapeWidth":533,"name":"Samsung Galaxy Beam I8530"},"samsunggalaxycameragc100":{"portraitWidth":360,"landscapeWidth":598,"name":"Samsung Galaxy Camera GC100"},"samsunggalaxyminis5570":{"portraitWidth":240,"landscapeWidth":320,"name":"Samsung Galaxy Mini S5570"},"samsunggalaxymini2s6500":{"portraitWidth":320,"landscapeWidth":480,"name":"Samsung Galaxy Mini 2 S6500"},"samsunggalaxynoten700":{"portraitWidth":400,"landscapeWidth":640,"name":"Samsung Galaxy Note N700"},"samsunggalaxynote10.1n8010":{"portraitWidth":800,"landscapeWidth":1280,"name":"Samsung Galaxy Note 10.1 N8010"},"samsunggalaxynote10.1n8010(multiscreenenabled)":{"portraitWidth":800,"landscapeWidth":637,"name":"Samsung Galaxy Note 10.1 N8010 (Multiscreen Enabled)"},"samsunggalaxynote10.1(2014edition)p600":{"portraitWidth":800,"landscapeWidth":1280,"name":"Samsung Galaxy Note 10.1 (2014 Edition) P600"},"samsunggalaxynote2n7100":{"portraitWidth":360,"landscapeWidth":640,"name":"Samsung Galaxy Note 2 N7100"},"samsunggalaxynote3n9005":{"portraitWidth":360,"landscapeWidth":640,"name":"Samsung Galaxy Note 3 N9005"},"samsunggalaxynote8.0n5100":{"portraitWidth":601,"landscapeWidth":962,"name":"Samsung Galaxy Note 8.0 N5100"},"samsunggalaxynote8.0n5110":{"portraitWidth":601,"landscapeWidth":962,"name":"Samsung Galaxy Note 8.0 N5110"},"samsunggalaxysi9000":{"portraitWidth":320,"landscapeWidth":533,"name":"Samsung Galaxy S I9000"},"samsunggalaxysduoss7562":{"portraitWidth":320,"landscapeWidth":533,"name":"Samsung Galaxy S Duos S7562"},"samsunggalaxyswifiypg70cw":{"portraitWidth":320,"landscapeWidth":533,"name":"Samsung Galaxy S WiFi YPG70CW"},"samsunggalaxys2i9100":{"portraitWidth":320,"landscapeWidth":533,"name":"Samsung Galaxy S2 I9100"},"samsunggalaxys3i9300":{"portraitWidth":360,"landscapeWidth":640,"name":"Samsung Galaxy S3 I9300"},"samsunggalaxys3minii8190":{"portraitWidth":320,"landscapeWidth":533,"name":"Samsung Galaxy S3 Mini I8190"},"samsunggalaxys4i9500":{"portraitWidth":360,"landscapeWidth":640,"name":"Samsung Galaxy S4 I9500"},"samsunggalaxys4i9505":{"portraitWidth":360,"landscapeWidth":640,"name":"Samsung Galaxy S4 I9505"},"samsunggalaxys4activei9295":{"portraitWidth":360,"landscapeWidth":640,"name":"Samsung Galaxy S4 Active I9295"},"samsunggalaxys4minii9190":{"portraitWidth":360,"landscapeWidth":640,"name":"Samsung Galaxy S4 Mini I9190"},"samsunggalaxys4zoomsm-c105":{"portraitWidth":360,"landscapeWidth":640,"name":"Samsung Galaxy S4 Zoom SM-C105"},"samsunggalaxytab10.1p7510":{"portraitWidth":800,"landscapeWidth":1280,"name":"Samsung Galaxy Tab 10.1 P7510"},"samsunggalaxytab210.1p5110":{"portraitWidth":800,"landscapeWidth":1280,"name":"Samsung Galaxy Tab 2 10.1 P5110"},"samsunggalaxytab27.0p3110":{"portraitWidth":600,"landscapeWidth":1024,"name":"Samsung Galaxy Tab 2 7.0 P3110"},"samsunggalaxytab37.0t210":{"portraitWidth":600,"landscapeWidth":1024,"name":"Samsung Galaxy Tab 3 7.0 T210"},"samsunggalaxytab38.0t310":{"portraitWidth":602,"landscapeWidth":962,"name":"Samsung Galaxy Tab 3 8.0 T310"},"samsunggalaxytab310.1p5210":{"portraitWidth":800,"landscapeWidth":1280,"name":"Samsung Galaxy Tab 3 10.1 P5210"},"samsunggalaxytab3kidst2105":{"portraitWidth":600,"landscapeWidth":1024,"name":"Samsung Galaxy Tab 3 Kids T2105"},"samsunggalaxytab7.7p6810":{"portraitWidth":800,"landscapeWidth":1280,"name":"Samsung Galaxy Tab 7.7 P6810"},"samsunggalaxytab7.0plusp6210":{"portraitWidth":600,"landscapeWidth":1024,"name":"Samsung Galaxy Tab 7.0 Plus P6210"},"samsunggalaxytab8.9p7310":{"portraitWidth":800,"landscapeWidth":1280,"name":"Samsung Galaxy Tab 8.9 P7310"},"samsunggalaxytab8.94gp7320":{"portraitWidth":800,"landscapeWidth":1280,"name":"Samsung Galaxy Tab 8.9 4G P7320"},"samsunggalaxytabp1000":{"portraitWidth":400,"landscapeWidth":683,"name":"Samsung Galaxy Tab P1000"},"samsunggalaxyxcover2s7710":{"portraitWidth":320,"landscapeWidth":533,"name":"Samsung Galaxy X Cover 2 S7710 "},"samsunggalaxyys5360":{"portraitWidth":320,"landscapeWidth":427,"name":"Samsung Galaxy Y S5360"},"samsunggalaxyyoungs6310":{"portraitWidth":320,"landscapeWidth":480,"name":"Samsung Galaxy Young S6310"},"samsunginfuse4gi997":{"portraitWidth":320,"landscapeWidth":533,"name":"Samsung Infuse 4G I997"},"samsungomniawi8350":{"portraitWidth":320,"landscapeWidth":480,"name":"Samsung Omnia W I8350"},"samsungomnia7i8700":{"portraitWidth":320,"landscapeWidth":480,"name":"Samsung Omnia 7 I8700"},"samsungwaves8500":{"portraitWidth":320,"landscapeWidth":534,"name":"Samsung Wave S8500"},"scrollexcel":{"portraitWidth":480,"landscapeWidth":800,"name":"Scroll Excel"},"sonyericssonxperiaarc":{"portraitWidth":320,"landscapeWidth":569,"name":"Sony Ericsson Xperia Arc"},"sonyericssonxperiaminist15i":{"portraitWidth":320,"landscapeWidth":401,"name":"Sony Ericsson Xperia Mini ST15i"},"sonyericssonxperianeo":{"portraitWidth":480,"landscapeWidth":854,"name":"Sony Ericsson Xperia Neo"},"sonyericcsonxperiaplay":{"portraitWidth":425,"landscapeWidth":974,"name":"Sony Ericcson Xperia Play"},"sonyericssonxperiax8":{"portraitWidth":320,"landscapeWidth":480,"name":"Sony Ericsson Xperia X8"},"sonyericssonxperiax10":{"portraitWidth":320,"landscapeWidth":569,"name":"Sony Ericsson Xperia X10"},"sonytablets":{"portraitWidth":800,"landscapeWidth":1280,"name":"Sony Tablet S"},"sonyvaiotap20":{"portraitWidth":900,"landscapeWidth":1600,"name":"Sony VAIO Tap 20"},"sonyxperiaacros":{"portraitWidth":360,"landscapeWidth":640,"name":"Sony Xperia acro S"},"sonyxperiap":{"portraitWidth":360,"landscapeWidth":640,"name":"Sony Xperia P"},"sonyxperias":{"portraitWidth":360,"landscapeWidth":640,"name":"Sony Xperia S"},"sonyxperiasola":{"portraitWidth":320,"landscapeWidth":569,"name":"Sony Xperia Sola"},"sonyxperiasp":{"portraitWidth":360,"landscapeWidth":598,"name":"Sony Xperia SP"},"sonyxperiatabletz":{"portraitWidth":800,"landscapeWidth":1280,"name":"Sony Xperia Tablet Z"},"sonyxperiatipo":{"portraitWidth":320,"landscapeWidth":480,"name":"Sony Xperia Tipo"},"sonyxperiau":{"portraitWidth":320,"landscapeWidth":569,"name":"Sony Xperia U"},"sonyxperiav":{"portraitWidth":360,"landscapeWidth":598,"name":"Sony Xperia V"},"sonyxperiaz":{"portraitWidth":360,"landscapeWidth":598,"name":"Sony Xperia Z"},"sonyxperiaz1":{"portraitWidth":360,"landscapeWidth":598,"name":"Sony Xperia Z1"},"telstrat-hub2":{"portraitWidth":400,"landscapeWidth":683,"name":"Telstra T-Hub 2"},"tescohudl":{"portraitWidth":600,"landscapeWidth":799,"name":"Tesco Hudl"},"toshibaat100":{"portraitWidth":800,"landscapeWidth":1280,"name":"Toshiba AT100"},"toshibaat1s0":{"portraitWidth":602,"landscapeWidth":961,"name":"Toshiba AT1S0"},"toshibaat200":{"portraitWidth":800,"landscapeWidth":1280,"name":"Toshiba AT200"},"toshibaat300":{"portraitWidth":800,"landscapeWidth":1280,"name":"Toshiba AT300"},"toshibaat330":{"portraitWidth":900,"landscapeWidth":1600,"name":"Toshiba AT330"},"wikocinkslim":{"portraitWidth":320,"landscapeWidth":533,"name":"Wiko Cink Slim"},"yarvikxentatab8c":{"portraitWidth":768,"landscapeWidth":1024,"name":"Yarvik Xenta Tab 8c"},"xiaomimi-3":{"portraitWidth":360,"landscapeWidth":640,"name":"Xiaomi MI-3"},"zteopen":{"portraitWidth":320,"landscapeWidth":415,"name":"ZTE Open"},"ztet22(telstraurbane)":{"portraitWidth":320,"landscapeWidth":533,"name":"ZTE T22 (Telstra Urbane)"},"ztet28(telstraactivetouch)":{"portraitWidth":320,"landscapeWidth":533,"name":"ZTE T28 (Telstra Active Touch)"},"ztet760(telstrasmart-touch2)":{"portraitWidth":320,"landscapeWidth":480,"name":"ZTE T760 (Telstra Smart-Touch 2)"},"ztet790(telstrapulse)":{"portraitWidth":320,"landscapeWidth":480,"name":"ZTE T790 (Telstra Pulse)"},"ztet81(telstrafrontier4g)":{"portraitWidth":320,"landscapeWidth":533,"name":"ZTE T81 (Telstra Frontier 4G)"},"ztet82(telstraeasytouch4g)":{"portraitWidth":360,"landscapeWidth":598,"name":"ZTE T82 (Telstra Easy Touch 4G)"},"ztet83(telstradave4g)":{"portraitWidth":320,"landscapeWidth":534,"name":"ZTE T83 (Telstra Dave 4G)"}}
+{
+  "iphone": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "iPhone"
+  },
+  "iphone3": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "iPhone 3"
+  },
+  "iphone3g": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "iPhone 3G"
+  },
+  "iphone3gs": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "iPhone 3GS"
+  },
+  "iphone4": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "iPhone 4"
+  },
+  "iphone4s": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "iPhone 4S"
+  },
+  "iphone5": {
+    "portraitWidth": 320,
+    "landscapeWidth": 568,
+    "name": "iPhone 5"
+  },
+  "iphone5c": {
+    "portraitWidth": 320,
+    "landscapeWidth": 568,
+    "name": "iPhone 5c"
+  },
+  "iphone5s": {
+    "portraitWidth": 320,
+    "landscapeWidth": 568,
+    "name": "iPhone 5s"
+  },
+  "iphone6": {
+    "portraitWidth": 375,
+    "landscapeWidth": 667,
+    "name": "iPhone 6"
+  },
+  "iphone6plus": {
+    "portraitWidth": 414,
+    "landscapeWidth": 736,
+    "name": "iPhone 6 Plus"
+  },
+  "iphone6s": {
+    "portraitWidth": 375,
+    "landscapeWidth": 667,
+    "name": "iPhone 6s"
+  },
+  "iphone6splus": {
+    "portraitWidth": 414,
+    "landscapeWidth": 736,
+    "name": "iPhone 6S Plus"
+  },
+  "iphone7": {
+    "portraitWidth": 375,
+    "landscapeWidth": 667,
+    "name": "iPhone 7"
+  },
+  "iphone7plus": {
+    "portraitWidth": 414,
+    "landscapeWidth": 736,
+    "name": "iPhone 7 Plus"
+  },
+  "iphone8": {
+    "portraitWidth": 375,
+    "landscapeWidth": 667,
+    "name": "iPhone 8"
+  },
+  "iphone8plus": {
+    "portraitWidth": 414,
+    "landscapeWidth": 736,
+    "name": "iPhone 8 Plus"
+  },
+  "iphonex": {
+    "portraitWidth": 375,
+    "landscapeWidth": 812,
+    "name": "iPhone X"
+  },
+  "iphonexr": {
+    "portraitWidth": 414,
+    "landscapeWidth": 896,
+    "name": "iPhone XR"
+  },
+  "iphonexs": {
+    "portraitWidth": 375,
+    "landscapeWidth": 812,
+    "name": "iPhone XS"
+  },
+  "iphonexsmax": {
+    "portraitWidth": 414,
+    "landscapeWidth": 896,
+    "name": "iPhone XS Max"
+  },
+  "iphone11": {
+    "portraitWidth": 414,
+    "landscapeWidth": 896,
+    "name": "iPhone 11"
+  },
+  "ipodtouch4thgen": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "iPod Touch 4th Gen"
+  },
+  "ipodtouch5thgen": {
+    "portraitWidth": 320,
+    "landscapeWidth": 568,
+    "name": "iPod Touch 5th Gen"
+  },
+  "ipad": {
+    "portraitWidth": 768,
+    "landscapeWidth": 1024,
+    "name": "iPad"
+  },
+  "ipad2": {
+    "portraitWidth": 768,
+    "landscapeWidth": 1024,
+    "name": "iPad 2"
+  },
+  "ipad3": {
+    "portraitWidth": 768,
+    "landscapeWidth": 1024,
+    "name": "iPad 3"
+  },
+  "ipadair": {
+    "portraitWidth": 768,
+    "landscapeWidth": 1024,
+    "name": "iPad Air"
+  },
+  "ipadair2": {
+    "portraitWidth": 768,
+    "landscapeWidth": 1024,
+    "name": "iPad Air 2"
+  },
+  "ipadmini": {
+    "portraitWidth": 768,
+    "landscapeWidth": 1024,
+    "name": "iPad Mini"
+  },
+  "ipadpro": {
+    "portraitWidth": 1024,
+    "landscapeWidth": 1366,
+    "name": "iPad Pro"
+  },
+  "ipadpro9.7": {
+    "portraitWidth": 768,
+    "landscapeWidth": 1024,
+    "name": "iPad Pro 9.7"
+  },
+  "applewatchseries1,3(38mm)": {
+    "portraitWidth": 272,
+    "landscapeWidth": 340,
+    "name": "Apple Watch Series 1, 3 (38mm)"
+  },
+  "applewatchseries1,3(42mm)": {
+    "portraitWidth": 312,
+    "landscapeWidth": 390,
+    "name": "Apple Watch Series 1, 3 (42mm)"
+  },
+  "applewatchseries5(40mm)": {
+    "portraitWidth": 324,
+    "landscapeWidth": 394,
+    "name": "Apple Watch Series 5 (40mm)"
+  },
+  "applewatchseries5(44mm)": {
+    "portraitWidth": 368,
+    "landscapeWidth": 448,
+    "name": "Apple Watch Series 5 (44mm)"
+  },
+  "samsungativs": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "Samsung Ativ S"
+  },
+  "samsunggalaxy5/europai5500": {
+    "portraitWidth": 320,
+    "landscapeWidth": 427,
+    "name": "Samsung Galaxy 5/Europa I5500"
+  },
+  "samsunggalaxyace2i8160": {
+    "portraitWidth": 320,
+    "landscapeWidth": 533,
+    "name": "Samsung Galaxy Ace 2 I8160"
+  },
+  "samsunggalaxyacepluss7500": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "Samsung Galaxy Ace Plus S7500"
+  },
+  "samsunggalaxyaces5830": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "Samsung Galaxy Ace S5830"
+  },
+  "samsunggalaxybeami8530": {
+    "portraitWidth": 320,
+    "landscapeWidth": 533,
+    "name": "Samsung Galaxy Beam I8530"
+  },
+  "samsunggalaxycameragc100": {
+    "portraitWidth": 360,
+    "landscapeWidth": 598,
+    "name": "Samsung Galaxy Camera GC100"
+  },
+  "samsunggalaxyj3": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Samsung Galaxy J3"
+  },
+  "samsunggalaxyj7": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Samsung Galaxy J7"
+  },
+  "samsunggalaxymini2s6500": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "Samsung Galaxy Mini 2 S6500"
+  },
+  "samsunggalaxyminis5570": {
+    "portraitWidth": 240,
+    "landscapeWidth": 320,
+    "name": "Samsung Galaxy Mini S5570"
+  },
+  "samsunggalaxynexus": {
+    "portraitWidth": 360,
+    "landscapeWidth": 600,
+    "name": "Samsung Galaxy Nexus"
+  },
+  "samsunggalaxynote": {
+    "portraitWidth": 400,
+    "landscapeWidth": 640,
+    "name": "Samsung Galaxy Note"
+  },
+  "samsunggalaxynote10": {
+    "portraitWidth": 360,
+    "landscapeWidth": 718,
+    "name": "Samsung Galaxy Note 10"
+  },
+  "samsunggalaxynote10+": {
+    "portraitWidth": 360,
+    "landscapeWidth": 718,
+    "name": "Samsung Galaxy Note 10+"
+  },
+  "samsunggalaxynote10.1(2014edition)p600": {
+    "portraitWidth": 800,
+    "landscapeWidth": 1280,
+    "name": "Samsung Galaxy Note 10.1 (2014 Edition) P600"
+  },
+  "samsunggalaxynote10.1n8010": {
+    "portraitWidth": 800,
+    "landscapeWidth": 1280,
+    "name": "Samsung Galaxy Note 10.1 N8010"
+  },
+  "samsunggalaxynote10.1n8010(multiscreenenabled)": {
+    "portraitWidth": 800,
+    "landscapeWidth": 637,
+    "name": "Samsung Galaxy Note 10.1 N8010 (Multiscreen Enabled)"
+  },
+  "samsunggalaxynote2": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Samsung Galaxy Note 2"
+  },
+  "samsunggalaxynote2n7100": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Samsung Galaxy Note 2 N7100"
+  },
+  "samsunggalaxynote3": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Samsung Galaxy Note 3"
+  },
+  "samsunggalaxynote3n9005": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Samsung Galaxy Note 3 N9005"
+  },
+  "samsunggalaxynote4": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Samsung Galaxy Note 4"
+  },
+  "samsunggalaxynote8": {
+    "portraitWidth": 360,
+    "landscapeWidth": 740,
+    "name": "Samsung Galaxy Note 8"
+  },
+  "samsunggalaxynote8.0n5100": {
+    "portraitWidth": 601,
+    "landscapeWidth": 962,
+    "name": "Samsung Galaxy Note 8.0 N5100"
+  },
+  "samsunggalaxynote8.0n5110": {
+    "portraitWidth": 601,
+    "landscapeWidth": 962,
+    "name": "Samsung Galaxy Note 8.0 N5110"
+  },
+  "samsunggalaxynote9": {
+    "portraitWidth": 360,
+    "landscapeWidth": 740,
+    "name": "Samsung Galaxy Note 9"
+  },
+  "samsunggalaxynoten700": {
+    "portraitWidth": 400,
+    "landscapeWidth": 640,
+    "name": "Samsung Galaxy Note N700"
+  },
+  "samsunggalaxys": {
+    "portraitWidth": 320,
+    "landscapeWidth": 533,
+    "name": "Samsung Galaxy S"
+  },
+  "samsunggalaxysduoss7562": {
+    "portraitWidth": 320,
+    "landscapeWidth": 533,
+    "name": "Samsung Galaxy S Duos S7562"
+  },
+  "samsunggalaxysi9000": {
+    "portraitWidth": 320,
+    "landscapeWidth": 533,
+    "name": "Samsung Galaxy S I9000"
+  },
+  "samsunggalaxyswifiypg70cw": {
+    "portraitWidth": 320,
+    "landscapeWidth": 533,
+    "name": "Samsung Galaxy S WiFi YPG70CW"
+  },
+  "samsunggalaxys10": {
+    "portraitWidth": 360,
+    "landscapeWidth": 740,
+    "name": "Samsung Galaxy S10"
+  },
+  "samsunggalaxys10+": {
+    "portraitWidth": 360,
+    "landscapeWidth": 740,
+    "name": "Samsung Galaxy S10+"
+  },
+  "samsunggalaxys2": {
+    "portraitWidth": 320,
+    "landscapeWidth": 533,
+    "name": "Samsung Galaxy S2"
+  },
+  "samsunggalaxys2i9100": {
+    "portraitWidth": 320,
+    "landscapeWidth": 533,
+    "name": "Samsung Galaxy S2 I9100"
+  },
+  "samsunggalaxys3": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Samsung Galaxy S3"
+  },
+  "samsunggalaxys3i9300": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Samsung Galaxy S3 I9300"
+  },
+  "samsunggalaxys3mini": {
+    "portraitWidth": 320,
+    "landscapeWidth": 533,
+    "name": "Samsung Galaxy S3 mini"
+  },
+  "samsunggalaxys3minii8190": {
+    "portraitWidth": 320,
+    "landscapeWidth": 533,
+    "name": "Samsung Galaxy S3 Mini I8190"
+  },
+  "samsunggalaxys4": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Samsung Galaxy S4"
+  },
+  "samsunggalaxys4activei9295": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Samsung Galaxy S4 Active I9295"
+  },
+  "samsunggalaxys4i9500": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Samsung Galaxy S4 I9500"
+  },
+  "samsunggalaxys4i9505": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Samsung Galaxy S4 I9505"
+  },
+  "samsunggalaxys4mini": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Samsung Galaxy S4 mini"
+  },
+  "samsunggalaxys4minii9190": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Samsung Galaxy S4 Mini I9190"
+  },
+  "samsunggalaxys4zoomsm-c105": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Samsung Galaxy S4 Zoom SM-C105"
+  },
+  "samsunggalaxys5": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Samsung Galaxy S5"
+  },
+  "samsunggalaxys6": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Samsung Galaxy S6"
+  },
+  "samsunggalaxys7": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Samsung Galaxy S7"
+  },
+  "samsunggalaxys7edge": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Samsung Galaxy S7 Edge"
+  },
+  "samsunggalaxys8": {
+    "portraitWidth": 360,
+    "landscapeWidth": 740,
+    "name": "Samsung Galaxy S8"
+  },
+  "samsunggalaxys8plus": {
+    "portraitWidth": 412,
+    "landscapeWidth": 846,
+    "name": "Samsung Galaxy S8 Plus"
+  },
+  "samsunggalaxys8+": {
+    "portraitWidth": 360,
+    "landscapeWidth": 740,
+    "name": "Samsung Galaxy S8+"
+  },
+  "samsunggalaxys9": {
+    "portraitWidth": 360,
+    "landscapeWidth": 740,
+    "name": "Samsung Galaxy S9"
+  },
+  "samsunggalaxys9plus": {
+    "portraitWidth": 412,
+    "landscapeWidth": 846,
+    "name": "Samsung Galaxy S9 Plus"
+  },
+  "samsunggalaxys9+": {
+    "portraitWidth": 360,
+    "landscapeWidth": 740,
+    "name": "Samsung Galaxy S9+"
+  },
+  "samsunggalaxytab": {
+    "portraitWidth": 800,
+    "landscapeWidth": 1280,
+    "name": "Samsung Galaxy Tab"
+  },
+  "samsunggalaxytab10.1p7510": {
+    "portraitWidth": 800,
+    "landscapeWidth": 1280,
+    "name": "Samsung Galaxy Tab 10.1 P7510"
+  },
+  "samsunggalaxytab2": {
+    "portraitWidth": 800,
+    "landscapeWidth": 1280,
+    "name": "Samsung Galaxy Tab 2"
+  },
+  "samsunggalaxytab210.1p5110": {
+    "portraitWidth": 800,
+    "landscapeWidth": 1280,
+    "name": "Samsung Galaxy Tab 2 10.1 P5110"
+  },
+  "samsunggalaxytab27\"": {
+    "portraitWidth": 600,
+    "landscapeWidth": 1024,
+    "name": "Samsung Galaxy Tab 2 7\""
+  },
+  "samsunggalaxytab27.0p3110": {
+    "portraitWidth": 600,
+    "landscapeWidth": 1024,
+    "name": "Samsung Galaxy Tab 2 7.0 P3110"
+  },
+  "samsunggalaxytab3": {
+    "portraitWidth": 800,
+    "landscapeWidth": 1280,
+    "name": "Samsung Galaxy Tab 3"
+  },
+  "samsunggalaxytab310.1p5210": {
+    "portraitWidth": 800,
+    "landscapeWidth": 1280,
+    "name": "Samsung Galaxy Tab 3 10.1 P5210"
+  },
+  "samsunggalaxytab37.0t210": {
+    "portraitWidth": 600,
+    "landscapeWidth": 1024,
+    "name": "Samsung Galaxy Tab 3 7.0 T210"
+  },
+  "samsunggalaxytab38.0t310": {
+    "portraitWidth": 602,
+    "landscapeWidth": 962,
+    "name": "Samsung Galaxy Tab 3 8.0 T310"
+  },
+  "samsunggalaxytab3kidst2105": {
+    "portraitWidth": 600,
+    "landscapeWidth": 1024,
+    "name": "Samsung Galaxy Tab 3 Kids T2105"
+  },
+  "samsunggalaxytab7.0plusp6210": {
+    "portraitWidth": 600,
+    "landscapeWidth": 1024,
+    "name": "Samsung Galaxy Tab 7.0 Plus P6210"
+  },
+  "samsunggalaxytab7.7p6810": {
+    "portraitWidth": 800,
+    "landscapeWidth": 1280,
+    "name": "Samsung Galaxy Tab 7.7 P6810"
+  },
+  "samsunggalaxytab8.94gp7320": {
+    "portraitWidth": 800,
+    "landscapeWidth": 1280,
+    "name": "Samsung Galaxy Tab 8.9 4G P7320"
+  },
+  "samsunggalaxytab8.9p7310": {
+    "portraitWidth": 800,
+    "landscapeWidth": 1280,
+    "name": "Samsung Galaxy Tab 8.9 P7310"
+  },
+  "samsunggalaxytabp1000": {
+    "portraitWidth": 400,
+    "landscapeWidth": 683,
+    "name": "Samsung Galaxy Tab P1000"
+  },
+  "samsunggalaxyxcover2s7710": {
+    "portraitWidth": 320,
+    "landscapeWidth": 533,
+    "name": "Samsung Galaxy X Cover 2 S7710"
+  },
+  "samsunggalaxyys5360": {
+    "portraitWidth": 320,
+    "landscapeWidth": 427,
+    "name": "Samsung Galaxy Y S5360"
+  },
+  "samsunggalaxyyoungs6310": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "Samsung Galaxy Young S6310"
+  },
+  "samsunginfuse4gi997": {
+    "portraitWidth": 320,
+    "landscapeWidth": 533,
+    "name": "Samsung Infuse 4G I997"
+  },
+  "samsungnexus10": {
+    "portraitWidth": 800,
+    "landscapeWidth": 1280,
+    "name": "Samsung Nexus 10"
+  },
+  "samsungomnia7i8700": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "Samsung Omnia 7 I8700"
+  },
+  "samsungomniawi8350": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "Samsung Omnia W I8350"
+  },
+  "samsungwaves8500": {
+    "portraitWidth": 320,
+    "landscapeWidth": 534,
+    "name": "Samsung Wave S8500"
+  },
+  "acericoniataba1-810": {
+    "portraitWidth": 768,
+    "landscapeWidth": 1024,
+    "name": "Acer Iconia Tab A1-810"
+  },
+  "acericoniataba100": {
+    "portraitWidth": 800,
+    "landscapeWidth": 1280,
+    "name": "Acer Iconia Tab A100"
+  },
+  "acericoniataba101": {
+    "portraitWidth": 600,
+    "landscapeWidth": 1024,
+    "name": "Acer Iconia Tab A101"
+  },
+  "acericoniataba200": {
+    "portraitWidth": 800,
+    "landscapeWidth": 1280,
+    "name": "Acer Iconia Tab A200"
+  },
+  "acericoniataba500": {
+    "portraitWidth": 648,
+    "landscapeWidth": 1280,
+    "name": "Acer Iconia Tab A500"
+  },
+  "acericoniataba501": {
+    "portraitWidth": 800,
+    "landscapeWidth": 1280,
+    "name": "Acer Iconia Tab A501"
+  },
+  "acerliquide2": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "ACER Liquid E2"
+  },
+  "ainolnovo7elf2": {
+    "portraitWidth": 496,
+    "landscapeWidth": 1024,
+    "name": "Ainol Novo 7 Elf 2"
+  },
+  "alcatel(vodafone)smartmini875": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "Alcatel (Vodafone) Smart Mini 875"
+  },
+  "alcatela30fierce": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Alcatel A30 Fierce"
+  },
+  "alcatelonetouch903": {
+    "portraitWidth": 320,
+    "landscapeWidth": 427,
+    "name": "Alcatel One Touch 903"
+  },
+  "alcatelonetouchidolx": {
+    "portraitWidth": 480,
+    "landscapeWidth": 800,
+    "name": "Alcatel One Touch Idol X"
+  },
+  "alcatelonetoucht10": {
+    "portraitWidth": 480,
+    "landscapeWidth": 800,
+    "name": "Alcatel One Touch T10"
+  },
+  "amicroe7touchtabii": {
+    "portraitWidth": 480,
+    "landscapeWidth": 800,
+    "name": "Amicroe 7 TouchTAB II"
+  },
+  "amicroe9.7touchtabiv": {
+    "portraitWidth": 768,
+    "landscapeWidth": 1024,
+    "name": "Amicroe 9.7 TouchTAB IV"
+  },
+  "archos70b(it2)": {
+    "portraitWidth": 600,
+    "landscapeWidth": 1024,
+    "name": "Archos 70b (it2)"
+  },
+  "archos80g9": {
+    "portraitWidth": 768,
+    "landscapeWidth": 1024,
+    "name": "Archos 80G9"
+  },
+  "arnova10bg3": {
+    "portraitWidth": 600,
+    "landscapeWidth": 1024,
+    "name": "Arnova 10b G3"
+  },
+  "arnova7g2": {
+    "portraitWidth": 480,
+    "landscapeWidth": 800,
+    "name": "Arnova 7 G2"
+  },
+  "arnova7fg3": {
+    "portraitWidth": 640,
+    "landscapeWidth": 1067,
+    "name": "Arnova 7F G3"
+  },
+  "arnova8cg3": {
+    "portraitWidth": 800,
+    "landscapeWidth": 1067,
+    "name": "Arnova 8C G3"
+  },
+  "asusb1-a71": {
+    "portraitWidth": 600,
+    "landscapeWidth": 1024,
+    "name": "ASUS B1-A71"
+  },
+  "asusfonepad": {
+    "portraitWidth": 601,
+    "landscapeWidth": 962,
+    "name": "ASUS Fonepad"
+  },
+  "asusmemopadfhd10/me302c10.1": {
+    "portraitWidth": 800,
+    "landscapeWidth": 1280,
+    "name": "ASUS MeMo Pad FHD10/ME302C 10.1"
+  },
+  "asusmemopadme172v": {
+    "portraitWidth": 600,
+    "landscapeWidth": 1024,
+    "name": "ASUS MeMo Pad ME172V"
+  },
+  "asusnexus7(v1)": {
+    "portraitWidth": 604,
+    "landscapeWidth": 966,
+    "name": "Asus Nexus 7 (v1)"
+  },
+  "asusnexus7(v2)": {
+    "portraitWidth": 600,
+    "landscapeWidth": 960,
+    "name": "Asus Nexus 7 (v2)"
+  },
+  "asuspadfone": {
+    "portraitWidth": 800,
+    "landscapeWidth": 1128,
+    "name": "ASUS Padfone"
+  },
+  "asustransformerpadtf300t": {
+    "portraitWidth": 800,
+    "landscapeWidth": 1280,
+    "name": "ASUS Transformer Pad TF300T"
+  },
+  "asustransformertf101": {
+    "portraitWidth": 800,
+    "landscapeWidth": 1280,
+    "name": "ASUS Transformer TF101"
+  },
+  "asusvivo": {
+    "portraitWidth": 768,
+    "landscapeWidth": 1366,
+    "name": "ASUS Vivo"
+  },
+  "barnes&amp;noblenookhd": {
+    "portraitWidth": 600,
+    "landscapeWidth": 960,
+    "name": "Barnes &amp; Noble Nook HD"
+  },
+  "bauhnamid-972xs": {
+    "portraitWidth": 768,
+    "landscapeWidth": 1024,
+    "name": "BAUHN AMID-972XS"
+  },
+  "bauhnamid-9743g": {
+    "portraitWidth": 768,
+    "landscapeWidth": 1024,
+    "name": "BAUHN AMID-9743G"
+  },
+  "bauhnasp-5000h": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "BAUHN ASP-5000H"
+  },
+  "blackberry9520": {
+    "portraitWidth": 345,
+    "landscapeWidth": 691,
+    "name": "BlackBerry 9520"
+  },
+  "blackberryclassic": {
+    "portraitWidth": 390,
+    "landscapeWidth": 390,
+    "name": "Blackberry Classic"
+  },
+  "blackberrycurve9380": {
+    "portraitWidth": 320,
+    "landscapeWidth": 406,
+    "name": "BlackBerry Curve 9380"
+  },
+  "blackberryleap": {
+    "portraitWidth": 390,
+    "landscapeWidth": 695,
+    "name": "Blackberry Leap"
+  },
+  "blackberrypassport": {
+    "portraitWidth": 504,
+    "landscapeWidth": 504,
+    "name": "Blackberry Passport\t"
+  },
+  "blackberryplaybook": {
+    "portraitWidth": 600,
+    "landscapeWidth": 1024,
+    "name": "Blackberry Playbook"
+  },
+  "blackberryq10": {
+    "portraitWidth": 346,
+    "landscapeWidth": 346,
+    "name": "Blackberry Q10"
+  },
+  "blackberrytorch9800": {
+    "portraitWidth": 360,
+    "landscapeWidth": 480,
+    "name": "Blackberry Torch 9800"
+  },
+  "blackberrytorch9860": {
+    "portraitWidth": 320,
+    "landscapeWidth": 505,
+    "name": "BlackBerry Torch 9860"
+  },
+  "blackberryz10": {
+    "portraitWidth": 384,
+    "landscapeWidth": 640,
+    "name": "Blackberry Z10"
+  },
+  "blackberryz30": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Blackberry Z30"
+  },
+  "dellvenue8": {
+    "portraitWidth": 800,
+    "landscapeWidth": 1280,
+    "name": "Dell Venue 8"
+  },
+  "galaxynexus": {
+    "portraitWidth": 360,
+    "landscapeWidth": 598,
+    "name": "Galaxy Nexus"
+  },
+  "googlenexus5": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Google Nexus 5"
+  },
+  "googlenexus6": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Google Nexus 6"
+  },
+  "googlenexus6p": {
+    "portraitWidth": 412,
+    "landscapeWidth": 738,
+    "name": "Google Nexus 6P"
+  },
+  "googlepixel": {
+    "portraitWidth": 411,
+    "landscapeWidth": 731,
+    "name": "Google Pixel"
+  },
+  "googlepixel2": {
+    "portraitWidth": 412,
+    "landscapeWidth": 640,
+    "name": "Google Pixel 2"
+  },
+  "googlepixel2xl": {
+    "portraitWidth": 412,
+    "landscapeWidth": 823,
+    "name": "Google Pixel 2 XL"
+  },
+  "googlepixel3": {
+    "portraitWidth": 393,
+    "landscapeWidth": 786,
+    "name": "Google Pixel 3"
+  },
+  "googlepixel3xl": {
+    "portraitWidth": 393,
+    "landscapeWidth": 786,
+    "name": "Google Pixel 3 XL"
+  },
+  "googlepixelxl": {
+    "portraitWidth": 411,
+    "landscapeWidth": 731,
+    "name": "Google Pixel XL"
+  },
+  "hpslate72800": {
+    "portraitWidth": 600,
+    "landscapeWidth": 1024,
+    "name": "HP Slate 7 2800"
+  },
+  "hptouchpad": {
+    "portraitWidth": 768,
+    "landscapeWidth": 1024,
+    "name": "HP Touchpad"
+  },
+  "hpveer": {
+    "portraitWidth": 320,
+    "landscapeWidth": 545,
+    "name": "HP Veer"
+  },
+  "htc7mozart": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "HTC 7 Mozart"
+  },
+  "htc7trophy": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "HTC 7 Trophy"
+  },
+  "htc8x": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "HTC 8X"
+  },
+  "htca620b": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "HTC A620b"
+  },
+  "htcdesire": {
+    "portraitWidth": 320,
+    "landscapeWidth": 533,
+    "name": "HTC Desire"
+  },
+  "htcdesire700": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "HTC Desire 700"
+  },
+  "htcdesirec": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "HTC Desire C"
+  },
+  "htcdesirehd": {
+    "portraitWidth": 320,
+    "landscapeWidth": 533,
+    "name": "HTC Desire HD"
+  },
+  "htcdesires": {
+    "portraitWidth": 320,
+    "landscapeWidth": 533,
+    "name": "HTC Desire S"
+  },
+  "htcdesirex": {
+    "portraitWidth": 320,
+    "landscapeWidth": 533,
+    "name": "HTC Desire X"
+  },
+  "htcdesirez(vision)": {
+    "portraitWidth": 480,
+    "landscapeWidth": 800,
+    "name": "HTC Desire Z (Vision)"
+  },
+  "htcdroideris": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "HTC Droid Eris"
+  },
+  "htcevo3d": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "HTC Evo 3D"
+  },
+  "htcincredible2": {
+    "portraitWidth": 320,
+    "landscapeWidth": 533,
+    "name": "HTC Incredible 2"
+  },
+  "htclegend": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "HTC Legend"
+  },
+  "htcmytouchslide4g": {
+    "portraitWidth": 320,
+    "landscapeWidth": 533,
+    "name": "HTC MyTouch Slide 4G"
+  },
+  "htcnexus9": {
+    "portraitWidth": 768,
+    "landscapeWidth": 1024,
+    "name": "HTC Nexus 9"
+  },
+  "htcone": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "HTC One"
+  },
+  "htcone1080": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "HTC One\t1080"
+  },
+  "htconemini": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "HTC One Mini"
+  },
+  "htcones": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "HTC One S"
+  },
+  "htconesv": {
+    "portraitWidth": 320,
+    "landscapeWidth": 533,
+    "name": "HTC One SV"
+  },
+  "htconev": {
+    "portraitWidth": 320,
+    "landscapeWidth": 533,
+    "name": "HTC One V"
+  },
+  "htconex": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "HTC One X"
+  },
+  "htconex+": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "HTC One X+"
+  },
+  "htconexl": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "HTC One XL"
+  },
+  "htcrio8s": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "HTC Rio 8S"
+  },
+  "htcsensationxl": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "HTC Sensation XL"
+  },
+  "htctitanii/4g": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "HTC Titan II/4G"
+  },
+  "htcvelocity4g": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "HTC Velocity 4G"
+  },
+  "htcwildfirea3333": {
+    "portraitWidth": 267,
+    "landscapeWidth": 356,
+    "name": "HTC Wildfire A3333"
+  },
+  "htcwildfires": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "HTC Wildfire S"
+  },
+  "htcwindowsphone8s": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "HTC Windows Phone 8S"
+  },
+  "htcwindowsphone8x(c625b)": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "HTC Windows Phone 8X (C625b)"
+  },
+  "huaweiascendg510": {
+    "portraitWidth": 320,
+    "landscapeWidth": 569,
+    "name": "Huawei Ascend G510"
+  },
+  "huaweiascendmate": {
+    "portraitWidth": 480,
+    "landscapeWidth": 813,
+    "name": "Huawei Ascend Mate"
+  },
+  "huaweip10": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Huawei P10"
+  },
+  "huaweip10lite": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Huawei P10 Lite"
+  },
+  "huaweip20": {
+    "portraitWidth": 360,
+    "landscapeWidth": 748,
+    "name": "Huawei P20"
+  },
+  "huaweip20lite": {
+    "portraitWidth": 360,
+    "landscapeWidth": 760,
+    "name": "Huawei P20 Lite"
+  },
+  "huaweip20pro": {
+    "portraitWidth": 360,
+    "landscapeWidth": 747,
+    "name": "Huawei P20 Pro"
+  },
+  "huaweip8lite": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Huawei P8 Lite"
+  },
+  "huaweip9": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Huawei P9"
+  },
+  "huaweip9lite": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Huawei P9 Lite"
+  },
+  "huaweiu8650sonic": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "Huawei U8650 Sonic"
+  },
+  "huaweiu8860": {
+    "portraitWidth": 320,
+    "landscapeWidth": 544,
+    "name": "Huawei U8860"
+  },
+  "huaweiy300-0151": {
+    "portraitWidth": 320,
+    "landscapeWidth": 533,
+    "name": "Huawei Y300-0151"
+  },
+  "kindlefire2": {
+    "portraitWidth": 600,
+    "landscapeWidth": 963,
+    "name": "Kindle Fire 2"
+  },
+  "kindlefirehd": {
+    "portraitWidth": 533,
+    "landscapeWidth": 801,
+    "name": "Kindle Fire HD"
+  },
+  "kindlefirehd8.9": {
+    "portraitWidth": 800,
+    "landscapeWidth": 1220,
+    "name": "Kindle Fire HD 8.9"
+  },
+  "lenovoideataba1000": {
+    "portraitWidth": 600,
+    "landscapeWidth": 1024,
+    "name": "Lenovo IdeaTab A1000"
+  },
+  "lenovoideatabs6000": {
+    "portraitWidth": 800,
+    "landscapeWidth": 1280,
+    "name": "Lenovo IdeaTab S6000"
+  },
+  "lenovok900": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Lenovo K900"
+  },
+  "lenovoyogatablet10": {
+    "portraitWidth": 800,
+    "landscapeWidth": 1280,
+    "name": "Lenovo Yoga Tablet 10"
+  },
+  "lenovoyogatablet8": {
+    "portraitWidth": 602,
+    "landscapeWidth": 962,
+    "name": "Lenovo Yoga Tablet 8"
+  },
+  "lgally": {
+    "portraitWidth": 320,
+    "landscapeWidth": 533,
+    "name": "LG Ally"
+  },
+  "lgaristo2": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "LG Aristo 2"
+  },
+  "lggpad8.3": {
+    "portraitWidth": 600,
+    "landscapeWidth": 960,
+    "name": "LG G Pad 8.3"
+  },
+  "lgg2": {
+    "portraitWidth": 360,
+    "landscapeWidth": 598,
+    "name": "LG G2"
+  },
+  "lgg3": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "LG G3"
+  },
+  "lgg4": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "LG G4"
+  },
+  "lgg5": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "LG G5"
+  },
+  "lgk10": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "LG K10"
+  },
+  "lgk20": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "LG K20"
+  },
+  "lgk7": {
+    "portraitWidth": 320,
+    "landscapeWidth": 570,
+    "name": "LG K7"
+  },
+  "lgnexus4": {
+    "portraitWidth": 384,
+    "landscapeWidth": 640,
+    "name": "LG Nexus 4"
+  },
+  "lgnexus5": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "LG Nexus 5"
+  },
+  "lgoptimus2x": {
+    "portraitWidth": 320,
+    "landscapeWidth": 533,
+    "name": "LG Optimus 2x"
+  },
+  "lgoptimusblackp970": {
+    "portraitWidth": 320,
+    "landscapeWidth": 533,
+    "name": "LG Optimus Black P970"
+  },
+  "lgoptimusg": {
+    "portraitWidth": 384,
+    "landscapeWidth": 640,
+    "name": "LG Optimus G"
+  },
+  "lgoptimusge975": {
+    "portraitWidth": 384,
+    "landscapeWidth": 640,
+    "name": "LG Optimus G E975"
+  },
+  "lgoptimusl3e400": {
+    "portraitWidth": 320,
+    "landscapeWidth": 427,
+    "name": "LG Optimus L3 E400"
+  },
+  "lgoptimusl3iie425f": {
+    "portraitWidth": 320,
+    "landscapeWidth": 427,
+    "name": "LG Optimus L3 II E425f"
+  },
+  "lgoptimusl7p700": {
+    "portraitWidth": 320,
+    "landscapeWidth": 533,
+    "name": "LG Optimus L7 P700"
+  },
+  "lgoptimusl9p760": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "LG Optimus L9 P760"
+  },
+  "lgoptimuspadv900": {
+    "portraitWidth": 768,
+    "landscapeWidth": 1280,
+    "name": "LG Optimus Pad V900"
+  },
+  "lgstylo2": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "LG Stylo 2"
+  },
+  "lgtributehd": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "LG Tribute HD"
+  },
+  "lgv20": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "LG V20"
+  },
+  "lgviewtyku990": {
+    "portraitWidth": 240,
+    "landscapeWidth": 400,
+    "name": "LG Viewty KU990"
+  },
+  "lyff90m(kaios)": {
+    "portraitWidth": 240,
+    "landscapeWidth": 320,
+    "name": "Lyf F90M (KaiOS)"
+  },
+  "microsoftlumia1020": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "Microsoft Lumia 1020"
+  },
+  "microsoftlumia1520": {
+    "portraitWidth": 432,
+    "landscapeWidth": 768,
+    "name": "Microsoft Lumia 1520"
+  },
+  "microsoftlumia620": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "Microsoft Lumia 620"
+  },
+  "microsoftlumia830": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "Microsoft Lumia 830"
+  },
+  "microsoftlumia900": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "Microsoft Lumia 900"
+  },
+  "microsoftlumia920": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "Microsoft Lumia 920"
+  },
+  "microsoftlumia925": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "Microsoft Lumia 925"
+  },
+  "microsoftsurface": {
+    "portraitWidth": 768,
+    "landscapeWidth": 1366,
+    "name": "Microsoft Surface"
+  },
+  "microsoftsurfacepro": {
+    "portraitWidth": 720,
+    "landscapeWidth": 1280,
+    "name": "Microsoft Surface Pro"
+  },
+  "microsoftsurfacepro2": {
+    "portraitWidth": 720,
+    "landscapeWidth": 1280,
+    "name": "Microsoft Surface Pro 2"
+  },
+  "microsoftsurfacepro3": {
+    "portraitWidth": 1024,
+    "landscapeWidth": 1440,
+    "name": "Microsoft Surface Pro 3"
+  },
+  "motoroladefy": {
+    "portraitWidth": 320,
+    "landscapeWidth": 569,
+    "name": "Motorola Defy"
+  },
+  "motoroladefymini": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "Motorola Defy Mini"
+  },
+  "motoroladroid3": {
+    "portraitWidth": 360,
+    "landscapeWidth": 559,
+    "name": "Motorola Droid 3"
+  },
+  "motoroladroidbionic": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Motorola Droid Bionic"
+  },
+  "motoroladroidrazr": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Motorola Droid Razr"
+  },
+  "motoroladroidturbo": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Motorola DROID Turbo"
+  },
+  "motorolaelectrify2": {
+    "portraitWidth": 360,
+    "landscapeWidth": 598,
+    "name": "Motorola Electrify 2"
+  },
+  "motorolafirext": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "Motorola Fire XT"
+  },
+  "motorolaflipout": {
+    "portraitWidth": 320,
+    "landscapeWidth": 240,
+    "name": "Motorola FlipOut"
+  },
+  "motorolamilestone": {
+    "portraitWidth": 320,
+    "landscapeWidth": 569,
+    "name": "Motorola Milestone"
+  },
+  "motorolamotoe4": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Motorola Moto E4"
+  },
+  "motorolamotog": {
+    "portraitWidth": 360,
+    "landscapeWidth": 598,
+    "name": "Motorola Moto G"
+  },
+  "motorolamotog5plus": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Motorola Moto G5 Plus"
+  },
+  "motorolamotoz": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Motorola Moto Z"
+  },
+  "motorolamotozplay": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Motorola Moto Z Play"
+  },
+  "motorolamotoz2": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Motorola Moto Z2"
+  },
+  "motorolamotoz2play": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Motorola Moto Z2 Play"
+  },
+  "motorolanexus6": {
+    "portraitWidth": 412,
+    "landscapeWidth": 690,
+    "name": "Motorola Nexus 6"
+  },
+  "motorolarazrhd4g": {
+    "portraitWidth": 360,
+    "landscapeWidth": 598,
+    "name": "Motorola RAZR HD 4G"
+  },
+  "motorolarazrm4g": {
+    "portraitWidth": 360,
+    "landscapeWidth": 598,
+    "name": "Motorola RAZR M 4G"
+  },
+  "motorolarazrmaxx": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Motorola RAZR MAXX"
+  },
+  "motorolaxoom": {
+    "portraitWidth": 800,
+    "landscapeWidth": 1280,
+    "name": "Motorola Xoom"
+  },
+  "motorolaxoom2": {
+    "portraitWidth": 800,
+    "landscapeWidth": 1280,
+    "name": "Motorola Xoom 2"
+  },
+  "motorolaxoom2mediaedition": {
+    "portraitWidth": 800,
+    "landscapeWidth": 1280,
+    "name": "Motorola Xoom 2 Media Edition"
+  },
+  "nexus10": {
+    "portraitWidth": 800,
+    "landscapeWidth": 1280,
+    "name": "Nexus 10"
+  },
+  "nexus4": {
+    "portraitWidth": 384,
+    "landscapeWidth": 598,
+    "name": "Nexus 4"
+  },
+  "nexus5": {
+    "portraitWidth": 360,
+    "landscapeWidth": 598,
+    "name": "Nexus 5"
+  },
+  "nexus7": {
+    "portraitWidth": 601,
+    "landscapeWidth": 962,
+    "name": "Nexus 7"
+  },
+  "nexus7(2013)": {
+    "portraitWidth": 600,
+    "landscapeWidth": 960,
+    "name": "Nexus 7 (2013)"
+  },
+  "nexus7(lcddensitysetto175ppi)": {
+    "portraitWidth": 731,
+    "landscapeWidth": 1170,
+    "name": "Nexus 7 (LCD Density set to 175PPI)"
+  },
+  "nexusone": {
+    "portraitWidth": 320,
+    "landscapeWidth": 533,
+    "name": "Nexus One"
+  },
+  "nexuss": {
+    "portraitWidth": 320,
+    "landscapeWidth": 533,
+    "name": "Nexus S"
+  },
+  "nokia500": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Nokia 500"
+  },
+  "nokia700(operamobile)": {
+    "portraitWidth": 240,
+    "landscapeWidth": 427,
+    "name": "Nokia 700 (Opera Mobile)"
+  },
+  "nokialumia1520": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "Nokia Lumia 1520"
+  },
+  "nokialumia520": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "Nokia Lumia 520"
+  },
+  "nokialumia610": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "Nokia Lumia 610"
+  },
+  "nokialumia710": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "Nokia Lumia 710"
+  },
+  "nokialumia720": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "Nokia Lumia 720"
+  },
+  "nokialumia800": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "Nokia Lumia 800"
+  },
+  "nokialumia820": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "Nokia Lumia 820"
+  },
+  "nokialumia900": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "Nokia Lumia 900"
+  },
+  "nokialumia920": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "Nokia Lumia 920"
+  },
+  "nokialumia925": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "Nokia Lumia 925"
+  },
+  "nokian9": {
+    "portraitWidth": 320,
+    "landscapeWidth": 496,
+    "name": "Nokia N9"
+  },
+  "nokian900": {
+    "portraitWidth": 480,
+    "landscapeWidth": 800,
+    "name": "Nokia N900"
+  },
+  "oppoa37360x640": {
+    "portraitWidth": 720,
+    "landscapeWidth": 1280,
+    "name": "Oppo A37 360x640"
+  },
+  "palmpixi": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "Palm Pixi"
+  },
+  "panasonictoughpadfz-a1": {
+    "portraitWidth": 768,
+    "landscapeWidth": 1024,
+    "name": "Panasonic Toughpad FZ-A1"
+  },
+  "pantechvegan°6": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Pantech Vega n°6"
+  },
+  "pendopad10&quot;": {
+    "portraitWidth": 600,
+    "landscapeWidth": 1024,
+    "name": "PendoPad 10&quot;"
+  },
+  "pendopad7&quot;": {
+    "portraitWidth": 480,
+    "landscapeWidth": 800,
+    "name": "PendoPad 7&quot;"
+  },
+  "pioneerdreambook": {
+    "portraitWidth": 768,
+    "landscapeWidth": 1024,
+    "name": "Pioneer Dreambook"
+  },
+  "scrollexcel": {
+    "portraitWidth": 480,
+    "landscapeWidth": 800,
+    "name": "Scroll Excel"
+  },
+  "sonyericcsonxperiaplay": {
+    "portraitWidth": 425,
+    "landscapeWidth": 974,
+    "name": "Sony Ericcson Xperia Play"
+  },
+  "sonyericssonxperiaarc": {
+    "portraitWidth": 320,
+    "landscapeWidth": 569,
+    "name": "Sony Ericsson Xperia Arc"
+  },
+  "sonyericssonxperiaminist15i": {
+    "portraitWidth": 320,
+    "landscapeWidth": 401,
+    "name": "Sony Ericsson Xperia Mini ST15i"
+  },
+  "sonyericssonxperianeo": {
+    "portraitWidth": 480,
+    "landscapeWidth": 854,
+    "name": "Sony Ericsson Xperia Neo"
+  },
+  "sonyericssonxperiax10": {
+    "portraitWidth": 320,
+    "landscapeWidth": 569,
+    "name": "Sony Ericsson Xperia X10"
+  },
+  "sonyericssonxperiax8": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "Sony Ericsson Xperia X8"
+  },
+  "sonytablets": {
+    "portraitWidth": 800,
+    "landscapeWidth": 1280,
+    "name": "Sony Tablet S"
+  },
+  "sonyvaiotap20": {
+    "portraitWidth": 900,
+    "landscapeWidth": 1600,
+    "name": "Sony VAIO Tap 20"
+  },
+  "sonyxperiaacros": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Sony Xperia acro S"
+  },
+  "sonyxperiap": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Sony Xperia P"
+  },
+  "sonyxperias": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Sony Xperia S"
+  },
+  "sonyxperiasola": {
+    "portraitWidth": 320,
+    "landscapeWidth": 569,
+    "name": "Sony Xperia Sola"
+  },
+  "sonyxperiasp": {
+    "portraitWidth": 360,
+    "landscapeWidth": 598,
+    "name": "Sony Xperia SP"
+  },
+  "sonyxperiatabletz": {
+    "portraitWidth": 800,
+    "landscapeWidth": 1280,
+    "name": "Sony Xperia Tablet Z"
+  },
+  "sonyxperiatipo": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "Sony Xperia Tipo"
+  },
+  "sonyxperiau": {
+    "portraitWidth": 320,
+    "landscapeWidth": 569,
+    "name": "Sony Xperia U"
+  },
+  "sonyxperiav": {
+    "portraitWidth": 360,
+    "landscapeWidth": 598,
+    "name": "Sony Xperia V"
+  },
+  "sonyxperiaxa": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Sony Xperia XA"
+  },
+  "sonyxperiaz": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Sony Xperia Z"
+  },
+  "sonyxperiaz1": {
+    "portraitWidth": 360,
+    "landscapeWidth": 598,
+    "name": "Sony Xperia Z1"
+  },
+  "sonyxperiaz3": {
+    "portraitWidth": 360,
+    "landscapeWidth": 598,
+    "name": "Sony Xperia Z3"
+  },
+  "telstrat-hub2": {
+    "portraitWidth": 400,
+    "landscapeWidth": 683,
+    "name": "Telstra T-Hub 2"
+  },
+  "tescohudl": {
+    "portraitWidth": 600,
+    "landscapeWidth": 799,
+    "name": "Tesco Hudl"
+  },
+  "toshibaat100": {
+    "portraitWidth": 800,
+    "landscapeWidth": 1280,
+    "name": "Toshiba AT100"
+  },
+  "toshibaat1s0": {
+    "portraitWidth": 602,
+    "landscapeWidth": 961,
+    "name": "Toshiba AT1S0"
+  },
+  "toshibaat200": {
+    "portraitWidth": 800,
+    "landscapeWidth": 1280,
+    "name": "Toshiba AT200"
+  },
+  "toshibaat300": {
+    "portraitWidth": 800,
+    "landscapeWidth": 1280,
+    "name": "Toshiba AT300"
+  },
+  "toshibaat330": {
+    "portraitWidth": 900,
+    "landscapeWidth": 1600,
+    "name": "Toshiba AT330"
+  },
+  "vivoy55s360x640": {
+    "portraitWidth": 720,
+    "landscapeWidth": 1280,
+    "name": "Vivo Y55s 360x640"
+  },
+  "wikocinkslim": {
+    "portraitWidth": 320,
+    "landscapeWidth": 533,
+    "name": "Wiko Cink Slim"
+  },
+  "xiaomimi3": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Xiaomi Mi 3"
+  },
+  "xiaomimi4": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Xiaomi Mi 4"
+  },
+  "xiaomimi-3": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Xiaomi MI-3"
+  },
+  "xiaomiredmi4360x640": {
+    "portraitWidth": 720,
+    "landscapeWidth": 1280,
+    "name": "Xiaomi Redmi 4 360x640"
+  },
+  "xiaomiredmi4x": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Xiaomi Redmi 4X"
+  },
+  "xiaomiredminote3": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Xiaomi Redmi Note 3"
+  },
+  "xiaomiredminote4": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "Xiaomi Redmi Note 4"
+  },
+  "xiaomiredminote5": {
+    "portraitWidth": 393,
+    "landscapeWidth": 786,
+    "name": "Xiaomi Redmi Note 5"
+  },
+  "yarvikxentatab8c": {
+    "portraitWidth": 768,
+    "landscapeWidth": 1024,
+    "name": "Yarvik Xenta Tab 8c"
+  },
+  "ztebladex": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "ZTE Blade X"
+  },
+  "ztegrands": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "ZTE Grand S"
+  },
+  "ztemajestypro": {
+    "portraitWidth": 320,
+    "landscapeWidth": 570,
+    "name": "ZTE Majesty Pro"
+  },
+  "ztemaven3": {
+    "portraitWidth": 320,
+    "landscapeWidth": 570,
+    "name": "ZTE Maven 3"
+  },
+  "ztemaxxl": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "ZTE Max XL"
+  },
+  "zteopen": {
+    "portraitWidth": 320,
+    "landscapeWidth": 415,
+    "name": "ZTE Open"
+  },
+  "zteopen(firefoxos)": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "ZTE Open (Firefox OS)"
+  },
+  "ztet22(telstraurbane)": {
+    "portraitWidth": 320,
+    "landscapeWidth": 533,
+    "name": "ZTE T22 (Telstra Urbane)"
+  },
+  "ztet28(telstraactivetouch)": {
+    "portraitWidth": 320,
+    "landscapeWidth": 533,
+    "name": "ZTE T28 (Telstra Active Touch)"
+  },
+  "ztet760(telstrasmart-touch2)": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "ZTE T760 (Telstra Smart-Touch 2)"
+  },
+  "ztet790(telstrapulse)": {
+    "portraitWidth": 320,
+    "landscapeWidth": 480,
+    "name": "ZTE T790 (Telstra Pulse)"
+  },
+  "ztet81(telstrafrontier4g)": {
+    "portraitWidth": 320,
+    "landscapeWidth": 533,
+    "name": "ZTE T81 (Telstra Frontier 4G)"
+  },
+  "ztet82(telstraeasytouch4g)": {
+    "portraitWidth": 360,
+    "landscapeWidth": 598,
+    "name": "ZTE T82 (Telstra Easy Touch 4G)"
+  },
+  "ztet83(telstradave4g)": {
+    "portraitWidth": 320,
+    "landscapeWidth": 534,
+    "name": "ZTE T83 (Telstra Dave 4G)"
+  },
+  "ztezmaxpro": {
+    "portraitWidth": 360,
+    "landscapeWidth": 640,
+    "name": "ZTE ZMAX Pro"
+  }
+}


### PR DESCRIPTION
Updated devices from the following sources:
1) https://deviceatlas.com/blog/viewport-resolution-diagonal-screen-size-and-dpi-most-popular-smartphones
This source is not outdated but obviously it will not be updated since it's just an article

2) http://viewportsizer.com/devices
Looked promising but it even does not have latest iphones

Unfortunately some devices are duplicated now, but contain more detailed information.
For example, `Goole Nexus 5`/`Nexus 5`/`LG Nexus 5`. I can remove duplicates but I will have to do it manually.

The order of devices is following:
- Iphones
- Ipads
- Apple watches (I think we can remove this item)
- Samsungs
- All other devices in alphabet order

I didn't remove any device from original list.