### PR TITLE
disable background tabs timer throttling

### DIFF
--- a/src/aliases.js
+++ b/src/aliases.js
@@ -8,6 +8,7 @@ const chromiumCmdArgs = [
     '--new-window',
     '--disable-background-networking',
     '--disable-ipc-flooding-protection',
+    '--disable-background-timer-throttling'
 ].join(' ');
 
 const ALIASES = {
@@ -60,7 +61,7 @@ const ALIASES = {
 
     'edge': {
         nameRe:             /edge/i,
-        cmd:                '--new-window',
+        cmd:                '--new-window --disable-background-timer-throttling',
         macOpenCmdTemplate: 'open -n -a "{{{path}}}" --args {{{pageUrl}}} {{{cmd}}}'
     },
 


### PR DESCRIPTION
Without this option, a testing page becomes extremely slow if a browser window is hidden (behind another window, for example).