### PR TITLE
Disabled profiles in PowerShell commands (DevExpress/testcafe#4665)

### DIFF
--- a/src/utils/exec.js
+++ b/src/utils/exec.js
@@ -23,10 +23,10 @@ const SYSTEM32_DIR      = path.join(WINDOWS_DIR, 'System32');
 const CHCP_COM          = path.join(SYSTEM32_DIR, 'chcp.com');
 const POWERSHELL_DIR    = path.join(SYSTEM32_DIR, 'WindowsPowerShell\\v1.0');
 const POWERSHELL_BINARY = path.join(POWERSHELL_DIR, 'powershell.exe');
-const POWERSHELL_ARGS   = ['-NoLogo', '-NonInteractive', '-Command'];
+const POWERSHELL_ARGS   = ['-NoProfile', '-NoLogo', '-NonInteractive', '-Command'];
 
 const POWERSHELL_COMMAND_WRAPPER = command => flattenWhitespace `
-    $cp = (${CHCP_COM} | Select-String '\\d+').Matches.Value;
+    $cp = (${CHCP_COM} | Select-String '\d+').Matches.Value;
     Try
     {
         ${CHCP_COM} 65001;


### PR DESCRIPTION
Closes DevExpress/testcafe#4665
Strict mode in PowerShell user profile caused testcafe to fail with exit code 1.
The error was caused by [this escape sequence](https://github.com/DevExpress/testcafe-browser-tools/blob/7fafae909b03c26fe41b6d0942c79585544fa8c8/src/utils/exec.js#L29) and the [issue with escape sequences](dmnd/dedent#24) in `dedent`.
