### PR TITLE
Auto-build binaries for target platforms via CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,78 @@
+name: Build multiplatform binaries
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        node: [10.x]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ matrix.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ matrix.os }}-build-${{ env.cache-name }}-
+            ${{ matrix.os }}-build-
+            ${{ matrix.os }}-
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Add msbuild to PATH
+        if: ${{ matrix.os == 'windows-latest' }}
+        uses: microsoft/setup-msbuild@v1
+
+      - name: Build on Linux
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: npx gulp buildLinux
+
+      - name: Build on MacOS
+        if: ${{ matrix.os == 'macos-latest' }}
+        run: npx gulp buildMac
+
+      - name: Build on Windows
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: npx gulp buildWindows
+
+      - name: Archive binaries on Linux
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: linux
+          path: bin/linux/**/*
+
+      - name: Archive binaries on MacOS
+        if: ${{ matrix.os == 'macos-latest' }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: mac
+          path: bin/mac/**/*
+
+      - name: Archive binaries on Windows
+        if: ${{ matrix.os == 'windows-latest' }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: win
+          path: bin/win/**/*

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -58,7 +58,8 @@ function buildWindowsUtilsDLL () {
         .src('src/natives/**/utils.csproj')
         .pipe(msbuild({
             targets:     ['Clean', 'Build'],
-            errorOnFail: true
+            errorOnFail: true,
+            stdout:      true
         }));
 }
 
@@ -67,7 +68,9 @@ function buildWindowsExecutables () {
         .src(['!src/natives/**/utils.csproj', 'src/natives/**/*.@(cs|vcx)proj'])
         .pipe(msbuild({
             targets:      ['Clean', 'Build'],
-            toolsVersion: 12.0
+            errorOnFail:  true,
+            toolsVersion: 'auto',
+            stdout:       true
         }));
 }
 

--- a/src/natives/generate-thumbnail/any/generate-thumbnail.vcxproj
+++ b/src/natives/generate-thumbnail/any/generate-thumbnail.vcxproj
@@ -18,13 +18,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>


### PR DESCRIPTION
## Purpose
Provide a way that would allow to automatically build on each platform. At the moment there are no alternative options to the approach except compiling binaries manually.

## Approach
- Added github workflow;
- Changed `gulp-msbuild` toolsVersion option to be automatically detected (used current version msbuild on github-runner, inst
ead of '4.0' by default);
- Changed `platformToolset` from VS13 to VS19 (installed on the `windows-latest` environment);

## Pre-Merge TODO
- [ ] Build both x86 and x64 (docker containers can be used)
- [ ] Make sure that binaries work as expected;