### PR TITLE
Support Edge on Linux

### DIFF
--- a/src/aliases.js
+++ b/src/aliases.js
@@ -62,7 +62,8 @@ const ALIASES = {
     'edge': {
         nameRe:             /edge/i,
         cmd:                '--new-window --disable-background-timer-throttling',
-        macOpenCmdTemplate: 'open -n -a "{{{path}}}" --args {{{pageUrl}}} {{{cmd}}}'
+        macOpenCmdTemplate: 'open -n -a "{{{path}}}" --args {{{pageUrl}}} {{{cmd}}}',
+        linuxBinaries:      ['microsoft-edge']
     },
 
     'edge-legacy': {


### PR DESCRIPTION
If you follow https://www.microsoftedgeinsider.com/en-us/download?platform=linux-deb Edge will be available under `/usr/bin/microsoft-edge`.