### PR TITLE
feat: disable Occlusion Tracking for Chromium/Edge

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-browser-tools",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "description": "An utility library for performing platform-dependent actions on browsers.",
   "homepage": "https://github.com/DevExpress/testcafe-browser-tools",
   "bugs": "https://github.com/DevExpress/testcafe-browser-tools/issues",

--- a/src/aliases.js
+++ b/src/aliases.js
@@ -8,7 +8,14 @@ const chromiumCmdArgs = [
     '--new-window',
     '--disable-background-networking',
     '--disable-ipc-flooding-protection',
-    '--disable-background-timer-throttling'
+    '--disable-background-timer-throttling',
+    '--disable-backgrounding-occluded-windows'
+].join(' ');
+
+const edgeCmdArgs = [
+    '--new-window',
+    '--disable-background-timer-throttling',
+    '--disable-backgrounding-occluded-windows'
 ].join(' ');
 
 const ALIASES = {
@@ -61,7 +68,7 @@ const ALIASES = {
 
     'edge': {
         nameRe:             /edge/i,
-        cmd:                '--new-window --disable-background-timer-throttling',
+        cmd:                edgeCmdArgs,
         macOpenCmdTemplate: 'open -n -a "{{{path}}}" --args {{{pageUrl}}} {{{cmd}}}',
         linuxBinaries:      ['microsoft-edge']
     },


### PR DESCRIPTION
Chromium/Edge backgrounds the renderer while the window is not visible to the user (e.g. covered by another window). We should add flag to disable such behavior.

[Description](https://peter.sh/experiments/chromium-command-line-switches/#disable-backgrounding-occluded-windows) of the used flag.

Manually tested on Windows and MacOS (Chrome/Edge). Start the test and open another window so that the browser window would be behind it. When the flag is set, test execution will not pause.

Closes #158